### PR TITLE
Fix for us-east-1 region InvalidLocationConstraint and build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # S3 Benchmark
 
 Your [Amazon S3](https://aws.amazon.com/s3/) performance depends on 3 things:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 # S3 Benchmark
 
 Your [Amazon S3](https://aws.amazon.com/s3/) performance depends on 3 things:
@@ -53,6 +54,27 @@ Or run the full test (takes a few hours):
 ```
 
 See [this](https://github.com/dvassallo/s3-benchmark/blob/master/main.go#L123-L134) for all the other options.
+
+### Build
+
+1. Install [Go](https://golang.org/)
+    ```
+    sudo apt-get install golang-go
+    ```
+    or
+    ```
+    sudo yum install go
+    ```
+    may work too. 
+    
+2. Setup Go environment variables (Usually GOPATH and GOBIN) and test Go installation 
+3. Clone the repo
+4. Install [```dep```](https://golang.github.io/dep/) 
+	```
+	go get -u github.com/golang/dep/cmd/dep
+	```
+5. Go to source directory and run ```dep ensure```
+6. Run ```go run main.go```
 
 ## S3 to EC2 Bandwidth
 

--- a/main.go
+++ b/main.go
@@ -218,7 +218,7 @@ func setup() {
 	createBucketReq := s3Client.CreateBucketRequest(&s3.CreateBucketInput{
 		Bucket: aws.String(bucketName),
 		CreateBucketConfiguration: &s3.CreateBucketConfiguration{
-			LocationConstraint: s3.BucketLocationConstraint(region),
+			LocationConstraint: s3.NormalizeBucketLocation(s3.BucketLocationConstraint(region)),
 		},
 	})
 	

--- a/main.go
+++ b/main.go
@@ -221,6 +221,14 @@ func setup() {
 			LocationConstraint: s3.BucketLocationConstraint(region),
 		},
 	})
+	
+	// AWS S3 has this peculiar issue in which if you want to create bucket in us-east-1 region, you should NOT specify 
+	// any location constraint. https://github.com/boto/boto3/issues/125
+	if strings.ToLower(region) == "us-east-1" {
+		createBucketReq = s3Client.CreateBucketRequest(&s3.CreateBucketInput{
+			Bucket: aws.String(bucketName),
+		})
+	}
 
 	_, err := createBucketReq.Send()
 


### PR DESCRIPTION
Unusually so, in order to create S3 bucket in us-east-1 region, no region shouldn't be specified. Not even 'us-east-1'. Wrapping with the Normalization function doesn't work too.  

I have added a special case for us-east-1 which has no LocationConstraint. I have tested this on us-east-1 and it works well. Works as usual in other regions too. This fixes #8

I have also added some build instructions. 

It's my first time writing any kind of Go code. Please give feedback and reject the pull request if needed. 

References: 
https://medium.com/@DQNEO/amazon-s3s-put-bucket-api-cannot-accept-us-east-1-region-6092df86991b

https://github.com/xiedeacc/go/blob/8df08858f48ef29d0b243f0f631afd961c8e0352/src/github.com/aws/aws-sdk-go-v2/service/s3/bucket_location.go#L92

https://github.com/s3tools/s3cmd/blob/ae6cddee12731ad611c422e8aacdb494bad0de73/S3/S3.py#L381

https://github.com/boto/boto3/issues/125